### PR TITLE
part of https://app.zenhub.com/workspaces/smartcolumbusos-5d08f55f08ccbe75911ce796/issues/smartcolumbusos/scosopedia/142

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN npm test
 
 FROM nginx
 RUN apt-get -y update &&\
-    apt-get install -y nginx-extras
+    apt-get install -y nginx-extras &&\
+    rm /etc/nginx/sites-enabled/default
 COPY --from=builder /app/src/dist /usr/share/nginx/html
 COPY --from=builder /app/src/run.sh /run.sh
 COPY ./default.conf /etc/nginx/conf.d/default.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN npm run build
 RUN npm test
 
 FROM nginx
+RUN apt-get -y update &&\
+    apt-get install -y nginx-extras
 COPY --from=builder /app/src/dist /usr/share/nginx/html
 COPY --from=builder /app/src/run.sh /run.sh
 COPY ./default.conf /etc/nginx/conf.d/default.conf

--- a/default.conf
+++ b/default.conf
@@ -7,6 +7,7 @@ server {
         index  index.html index.htm;
     }
 
+    # hides server header
     more_clear_headers Server;
     
     gzip on;

--- a/default.conf
+++ b/default.conf
@@ -7,7 +7,7 @@ server {
         index  index.html index.htm;
     }
 
-    # hides server header
+    # hides server header.
     more_clear_headers Server;
     
     gzip on;

--- a/default.conf
+++ b/default.conf
@@ -6,6 +6,8 @@ server {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
     }
+
+    more_clear_headers Server;
     
     gzip on;
     gzip_static on;    


### PR DESCRIPTION
https://app.zenhub.com/workspaces/smartcolumbusos-5d08f55f08ccbe75911ce796/issues/smartcolumbusos/scosopedia/142 is a card to disable or obfuscate all HTTP headers that disclose server information.

Added nginx-extras to dockerfile so I could use its more_clear_headers directive in nginx-default.conf. This clears the server header.